### PR TITLE
Collisions now adjacent

### DIFF
--- a/Resources/Level1.json
+++ b/Resources/Level1.json
@@ -19,6 +19,15 @@
       "name": "Wall.json",
       "transform": [
         {
+          "x": 550,
+          "y": 500
+        }
+      ]
+    },
+    {
+      "name": "Wall.json",
+      "transform": [
+        {
           "x": 600,
           "y": 600
         }


### PR DESCRIPTION
Colliding with a wall now brings you directly adjacent to the wall, rather than the previous lazy method of simply setting speed to 0.  This prevents issues of "levitating" when you approach the ground at high velocity, as well as cases where you could get too close to the wall and get stuck.